### PR TITLE
Updated file to pid library update

### DIFF
--- a/autopid/lib/autopidlib.lua
+++ b/autopid/lib/autopidlib.lua
@@ -54,7 +54,7 @@ end
 function autopid.shutdown()
   for _, controller in pairs(controllers) do
     controller.shutdown()
-    pid.remove(controller)
+    pid.remove(controller, true)
   end
 end
 

--- a/autopid/lib/autopidlib.lua
+++ b/autopid/lib/autopidlib.lua
@@ -7,10 +7,10 @@ local component = require("component")
 local superlib = require("superlib")
 local shell = require("shell")
 
-controllers = {}
+local controllers = {}
 
-turbines = 0
-reactors = 0
+local turbines = 0
+local reactors = 0
 
 local function loadFile(file, cid, address, type)
   local controller={}
@@ -31,8 +31,6 @@ local function loadFile(file, cid, address, type)
   controller.log = log
   controller.type = type
 
-  controllers[#controllers + 1] = cid
-
   assert(loadfile(file, "t",env))()
 
   return pid.new(controller, cid, true)
@@ -50,13 +48,13 @@ function autopid.scan()
       loadFile("/usr/autopid/reactor.apid", "reactor"..tostring(reactors), address, type)
     end
   end
-  controllers = pid.dump()
+  controllers = pid.registry()
 end
 
 function autopid.shutdown()
   for _, controller in pairs(controllers) do
     controller.shutdown()
-    pid.remove(controller.id)
+    pid.remove(controller)
   end
 end
 


### PR DESCRIPTION
- You now have built-in access to the registry table but it is read-only due to the second change! (I saw you modified my library to get access.)
- You can now unregister controllers without using their id by using pid.remove(controller).
-> The old pid.remove has been renamed to pid.removeID.
- The pid library doesn't automaticly stop a controller when it is overwritten in the registry anymore. You need to use an additional parameter now.

I also added some locals and removed an assignment to a table that you replace with another value in the next step.

And one last thing: I'm going to add my repository to oppm. As soon as this is done, I'd like to take over the mpmpid package. :-)